### PR TITLE
Octopus new css assignment 3.3

### DIFF
--- a/css/positioning/style.css
+++ b/css/positioning/style.css
@@ -1,0 +1,22 @@
+#octopus {
+ position: relative;
+  margin-top: 150px;
+  margin-left: 36%;
+  margin-right; 36%;
+  z-index: -1;
+
+}
+
+.accessories {
+  position: relative;
+  margin-top: -365px;
+
+}
+
+.hat{
+  margin-left: -15px;
+}
+
+.glasses {
+  margin-left: 40px;
+}


### PR DESCRIPTION
could not figure out css to keep octopus image centered relative to the default container so that it would always be centered no matter the viewport; also used negative numbers for margin positioning which I thought was frowned upon. Although this worked, I think there are better ways to code this  and will be keeping that in mind going forward.
